### PR TITLE
Fix for HA 2026.1

### DIFF
--- a/custom_components/indrav2h/__init__.py
+++ b/custom_components/indrav2h/__init__.py
@@ -10,7 +10,7 @@ from datetime import timedelta
 import traceback
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import Config
+from homeassistant.core_config import Config
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.aiohttp_client import async_get_clientsession


### PR DESCRIPTION
Hi, I have a small fix for HA 2026.1 which was released yesterday.

It's a switch to the new config namespace, deprecated since HA 2024.11 and removed in 2026.1.

I also want to mention that you may want to do a release in github, as it seems it's not possible to download the main branch directly in HACS if there are already releases. 