### PR TITLE
Removed deprecated call and fix entry setup logic

### DIFF
--- a/custom_components/indrav2h/__init__.py
+++ b/custom_components/indrav2h/__init__.py
@@ -98,14 +98,8 @@ class Indrav2hDataUpdateCoordinator(DataUpdateCoordinator):
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Handle removal of an entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
-    unloaded = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, platform)
-                for platform in PLATFORMS
-                if platform in coordinator.platforms
-            ]
-        )
+    unloaded = await hass.config_entries.async_unload_platforms(
+        entry, coordinator.platforms
     )
     if unloaded:
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/custom_components/indrav2h/__init__.py
+++ b/custom_components/indrav2h/__init__.py
@@ -61,9 +61,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     for platform in PLATFORMS:
         if entry.options.get(platform, True):
             coordinator.platforms.append(platform)
-            hass.async_add_job(
-                hass.config_entries.async_forward_entry_setups(entry, [platform])
-            )
+
+    await hass.config_entries.async_forward_entry_setups(entry, coordinator.platforms)
 
     entry.add_update_listener(async_reload_entry)
     return True


### PR DESCRIPTION
`async_add_job` is deprecated and was scheduled for removal in HomeAssistant 2025.4 (though it's still present as of 2026.6), printing a warning in the log.

`async_forward_entry_setups` must be awaited to ensure it finishes before the config entry setup is complete. This was not being done previously, again generating a warning in the log. The function can also forward setups for multiple platforms which is more efficient than being called repeatedly in a loop.

This change fixes two of the 3 deprecation warnings in creatingwake/ha-indrav2h#42 (one of which already has a workaround but this is the proper fix).