### PR TITLE
Support setting preset schedules

### DIFF
--- a/custom_components/indrav2h/select.py
+++ b/custom_components/indrav2h/select.py
@@ -14,7 +14,12 @@ async def async_setup_entry(hass, entry, async_add_devices):
     """Setup select platform."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
     # platform = entity_platform.async_get_current_platform()
-    async_add_devices([V2HOperatingModeSelect(coordinator, entry)])
+    async_add_devices(
+        [
+            V2HOperatingModeSelect(coordinator, entry),
+            V2HScheduleSelect(coordinator, entry),
+        ],
+    )
     
 
 
@@ -63,3 +68,43 @@ class V2HOperatingModeSelect(Indrav2hEntity, SelectEntity):
     def options(self):
         return list(V2H_MODES)
 
+
+class V2HScheduleSelect(Indrav2hEntity, SelectEntity):
+    """Select the preset schedule to be used."""
+
+    def __init__(self, coordinator, config_entry):
+        super().__init__(coordinator, config_entry)
+        self.device = coordinator.api.device
+
+    @property
+    def unique_id(self):
+        """Return a unique ID to use for this entity."""
+        return (
+            f"{self.config_entry.entry_id}-{self.device.serial}-active_schedule"
+        )
+
+    @property
+    def device_info(self):
+        """Return information to link this entity with the correct device."""
+        return {
+            "name": NAME,
+            "identifiers": {(DOMAIN, self.coordinator.api.device.serial)}
+            }
+
+    @property
+    def name(self):
+        """Return the name of the sensor."""
+        return "Indra V2H Active Schedule"
+
+    @property
+    def current_option(self):
+        """Return the state of the sensor."""
+        return self.device.loadedSchedule
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        await self.device.set_loaded_schedule(option)
+
+    @property
+    def options(self):
+        return sorted(self.device._schedule.presets.keys())


### PR DESCRIPTION
Requires pyindrav2h with schedule support. The schedule is implemented as a Select entity and polling for updates is handled by pyindrav2h in the data update coordinator.

This depends on https://github.com/creatingwake/pyindrav2h/pull/20 being merged and a new pyindrav2h release being pushed to PyPI. I haven't updated the integration version number or the pyindrav2h version requirement in manifest.json as they'll depend on what version number you choose when publishing the updated pyindrav2h package. For testing in my own fork I've made a `dev` branch which points to a specific pyindrav2h git commit in my fork and assigns an integration version number of v0.0.8.devN so I can make pre-releases which get loaded with HACS (got up to dev5 before I was happy with the implementation).

This should apply cleanly alongside #51 and doesn't depend on that one being merged first.